### PR TITLE
Add version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,20 @@ TEMPLATE_FILES := $(shell find boilerplate-templates -name "*.boilertmpl")
 
 GOLANGCI_LINT_VERSION := v1.52.2
 
+GOFLAGS := -trimpath
+
+RELEASE_VERSION := $(shell git describe --tags --match='v*' --abbrev=14)
+GITCOMMIT := $(shell git rev-parse HEAD)
+
+GOLDFLAGS := -w -s \
+	-X 'github.com/cert-manager/boilersuite/internal/version.AppVersion=$(RELEASE_VERSION)' \
+    -X 'github.com/cert-manager/boilersuite/internal/version.AppGitCommit=$(GITCOMMIT)'
+
 .PHONY: build
 build: $(BINDIR)/boilersuite
 
 $(BINDIR)/boilersuite: $(GO_FILES) $(TEMPLATE_FILES) | $(BINDIR)
-	CGO_ENABLED=0 go build -o $@ main.go
+	CGO_ENABLED=0 go build $(GOFLAGS) -ldflags "$(GOLDFLAGS)" -o $@ main.go
 
 .PHONY: test
 test:

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- munnerz
+- joshvanl
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish
+- inteon
+reviewers:
+- munnerz
+- joshvanl
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish
+- inteon

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+var (
+	// AppVersion is set by the Go linker
+	AppVersion = "development"
+
+	// AppGitCommit is set by the Go linker
+	AppGitCommit = "0000000000000000000000000000000000000000"
+)

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/cert-manager/boilersuite/internal/boilersuite"
+	"github.com/cert-manager/boilersuite/internal/version"
 )
 
 const (
@@ -50,11 +51,18 @@ func main() {
 	authorFlag := flag.String("author", defaultAuthor, fmt.Sprintf("The expected author for files, which will be substituted for the %q marker in templates", boilersuite.AuthorMarkerRegex))
 	verboseFlag := flag.Bool("verbose", false, "If set, prints verbose output")
 	cpuprofile := flag.String("cpuprofile", "", "If set, writes CPU profiling information to the given filename")
+	printVersion := flag.Bool("version", false, "If set, prints the version and exits")
 
 	flag.Parse()
 
+	if *printVersion {
+		logger.Printf("version: %s", version.AppVersion)
+		logger.Printf(" commit: %s", version.AppGitCommit)
+		os.Exit(0)
+	}
+
 	if flag.NArg() != 1 {
-		logger.Fatalf("usage: %s [--skip \"paths to skip\"] [--author \"example\"] [--verbose] <path-to-dir>", os.Args[0])
+		logger.Fatalf("usage: %s [--version] [--skip \"paths to skip\"] [--author \"example\"] [--verbose] <path-to-dir>", os.Args[0])
 	}
 
 	var skippedDirs []string

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	skipFlag := flag.String("skip", "", "Space-separated list of prefixes for paths which shouldn't be checked. Spaces in prefixes not supported.")
 	authorFlag := flag.String("author", defaultAuthor, fmt.Sprintf("The expected author for files, which will be substituted for the %q marker in templates", boilersuite.AuthorMarkerRegex))
 	verboseFlag := flag.Bool("verbose", false, "If set, prints verbose output")
-	cpuprofile := flag.String("cpuprofile", "", "If set, writes CPU profiling information to the given filename")
+	cpuProfile := flag.String("cpuprofile", "", "If set, writes CPU profiling information to the given filename")
 	printVersion := flag.Bool("version", false, "If set, prints the version and exits")
 
 	flag.Parse()
@@ -75,8 +75,8 @@ func main() {
 		verboseLogger = log.New(os.Stdout, "[VERBOSE] ", log.LstdFlags)
 	}
 
-	if *cpuprofile != "" {
-		f, err := os.Create(*cpuprofile)
+	if *cpuProfile != "" {
+		f, err := os.Create(*cpuProfile)
 		if err != nil {
 			logger.Fatal(err)
 		}


### PR DESCRIPTION
This is primarily intended as a test of boilersuite's CI, but it's also a useful feature in its own right.

After this, we'll tag v0.1.0 and cut a release

Note that the presubmit will have a line like this until we create the first tag:

```text
fatal: No names found, cannot describe anything.
```

It's not actually a fatal error, it's just saying we can't get the name of the latest tag