### PR TITLE
Add support for custom license templates

### DIFF
--- a/internal/boilersuite/template_map.go
+++ b/internal/boilersuite/template_map.go
@@ -17,17 +17,22 @@ limitations under the License.
 package boilersuite
 
 import (
-	"embed"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"strings"
 )
+
+type Filesystem interface {
+	fs.ReadDirFS
+	fs.ReadFileFS
+}
 
 type TemplateMap map[string]BoilerplateTemplate
 
 // LoadTemplates attempts to read all of the templates under the given embedded filesystem
 // and return a TemplateMap which can be used for fetching templates later.
-func LoadTemplates(templateDir embed.FS, expectedAuthor string) (TemplateMap, error) {
+func LoadTemplates(templateDir Filesystem, expectedAuthor string) (TemplateMap, error) {
 	allEntries, err := templateDir.ReadDir("boilerplate-templates")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read templates: %s", err.Error())

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ var (
 )
 
 //go:embed boilerplate-templates/*.boilertmpl
-var boilerplateTemplateDir embed.FS
+var apache2BoilerplateTemplateDir embed.FS
 
 func main() {
 	logger := log.New(os.Stdout, "", log.LstdFlags)
@@ -89,6 +89,11 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
+	var boilerplateTemplateDir boilersuite.Filesystem = apache2BoilerplateTemplateDir
+	if templateDir, hasTemplateDir := os.LookupEnv("BOILERSUITE_TEMPLATE_DIR"); hasTemplateDir {
+		boilerplateTemplateDir = os.DirFS(templateDir).(boilersuite.Filesystem)
+	}
+
 	templates, err := boilersuite.LoadTemplates(boilerplateTemplateDir, *authorFlag)
 	if err != nil {
 		logger.Fatalf("failed to load templates: %s", err.Error())
@@ -115,7 +120,7 @@ func main() {
 			logger.Fatalf("failed to read %q: %s", targetBase, err.Error())
 		}
 
-		targets = []target{target{
+		targets = []target{{
 			path:     targetBase,
 			contents: string(contents),
 		}}


### PR DESCRIPTION
Adds BOILERSUITE_TEMPLATE_DIR env variable that lets you specify your own license template folder